### PR TITLE
Add etcd lock implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     
+    - name: Grant execute permission for mvnw
+      run: chmod +x mvnw
+    
     - name: Set up JDK 8
       uses: actions/setup-java@v3
       with:
@@ -24,7 +27,7 @@ jobs:
       run: ./mvnw clean install
 
     - name: Test Coverage
-      run: ./mvnw clean test
+      run: ./mvnw test
 
     # 上传测试报告（如果需要的话）
     - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,5 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         cache: maven
         
     - name: Build with Maven
-      run: ./mvnw clean install
+      run: ./mvnw clean install -Dmaven.javadoc.failOnError=false -Dmaven.javadoc.skip=false -Dmaven.test.skip=false
 
     - name: Test Coverage
       run: ./mvnw test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "master", "feature/**" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+        cache: maven
+        
+    - name: Build with Maven
+      run: ./mvnw clean install
+
+    - name: Test Coverage
+      run: ./mvnw clean test
+
+    # 上传测试报告（如果需要的话）
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        fail_ci_if_error: true
+        verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
     - name: Build with Maven
       run: ./mvnw clean install -Dmaven.javadoc.failOnError=false -Dmaven.javadoc.skip=false -Dmaven.test.skip=false
 
-    - name: Test Coverage
-      run: ./mvnw test
+    - name: Run tests and generate coverage report
+      run: ./mvnw test org.jacoco:jacoco-maven-plugin:report
 
     # 上传测试报告（如果需要的话）
     - name: Upload coverage to Codecov

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic",
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/lock4j-core/pom.xml
+++ b/lock4j-core/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>spring-boot-starter-aop</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>

--- a/lock4j-core/src/main/java/com/baomidou/lock/AbortLockFailureStrategy.java
+++ b/lock4j-core/src/main/java/com/baomidou/lock/AbortLockFailureStrategy.java
@@ -16,8 +16,12 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * <p>当加锁失败时，抛出异常以终止方法执行。 <br/>
+ * <p>
+ * 当加锁失败时，抛出异常以终止方法执行。
+ * </p>
+ * <p>
  * 该策略可以通过{@link Options}注解来指定当失败时要抛出的异常和异常信息。
+ * </p>
  *
  * @author huangchengxing
  * @see Options
@@ -66,7 +70,7 @@ public class AbortLockFailureStrategy implements LockFailureStrategy {
     @Override
     public void onLockFailure(String key, Method method, Object[] arguments) throws Exception {
         exceptionHandlerCaches.computeIfAbsent(method, this::resolveExceptionHandler)
-            .handle(key, method, arguments);
+                .handle(key, method, arguments);
     }
 
     /**
@@ -78,30 +82,29 @@ public class AbortLockFailureStrategy implements LockFailureStrategy {
     @NonNull
     protected FailureHandler resolveExceptionHandler(Method method) {
         Options options = AnnotatedElementUtils.findMergedAnnotation(method, Options.class);
-        return Objects.isNull(options) ?
-            defaultExceptionFactory : new FailureMessageFailureHandler(options.lockFailureException(), options.lockFailureMessage());
+        return Objects.isNull(options) ? defaultExceptionFactory
+                : new FailureMessageFailureHandler(options.lockFailureException(), options.lockFailureMessage());
     }
 
     /**
      * 获取异常信息
      *
-     * @param key 获取失败的锁的key
-     * @param method 方法
-     * @param arguments 调用参数
+     * @param key        获取失败的锁的key
+     * @param method     方法
+     * @param arguments  调用参数
      * @param expression 用于获取异常信息的表达式
      * @return 异常信息
      */
     @Nullable
     protected final String resolveMessage(
-        String key, Method method, Object[] arguments, String expression) {
+            String key, Method method, Object[] arguments, String expression) {
         // 若未指定错误信息，则返回默认的异常信息
         if (!StringUtils.hasText(expression)) {
             return DEFAULT_EXCEPTION_MESSAGE;
         }
         try {
             return methodBasedExpressionEvaluator.getValue(
-                method, arguments, expression, String.class, Collections.singletonMap(KEY_NAME, key)
-            );
+                    method, arguments, expression, String.class, Collections.singletonMap(KEY_NAME, key));
         } catch (Exception ex) {
             if (allowedMakeNonExecutableExpressionsAsString) {
                 return expression;
@@ -150,11 +153,11 @@ public class AbortLockFailureStrategy implements LockFailureStrategy {
                 }
             }
             try {
-                return constructor.getParameterCount() > 0 ?
-                    constructor.newInstance(message) : constructor.newInstance();
+                return constructor.getParameterCount() > 0 ? constructor.newInstance(message)
+                        : constructor.newInstance();
             } catch (Exception e) {
                 throw new IllegalStateException("创建异常实例失败，指定的异常类型："
-                    + constructor.getDeclaringClass().getName() + "是否可以被实例化？", e);
+                        + constructor.getDeclaringClass().getName() + "是否可以被实例化？", e);
             }
         }
 
@@ -165,7 +168,7 @@ public class AbortLockFailureStrategy implements LockFailureStrategy {
                 constr = ClassUtils.getConstructorIfAvailable(exceptionType);
             }
             Assert.notNull(constr, "异常类型[" + exceptionType.getName() +
-                "]必须有一个无参构造函数，或有有一个接受String类型参数的造函数");
+                    "]必须有一个无参构造函数，或有有一个接受String类型参数的造函数");
             if (!constr.isAccessible()) {
                 ReflectionUtils.makeAccessible(constr);
             }
@@ -178,20 +181,22 @@ public class AbortLockFailureStrategy implements LockFailureStrategy {
      *
      * @author huangchengxing
      */
-    @Target(value = {ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+    @Target(value = { ElementType.METHOD, ElementType.ANNOTATION_TYPE })
     @Retention(value = RetentionPolicy.RUNTIME)
     @Inherited
     @Documented
     public @interface Options {
 
         /**
-         * <p>抛出异常的错误消息。
+         * <p>
+         * 抛出异常的错误消息。
          *
-         * <p>错误信息支持 SpEL 表达式，你可以在表达式中引用上下文参数：
+         * <p>
+         * 错误信息支持 SpEL 表达式，你可以在表达式中引用上下文参数：
          * <ul>
-         *     <li>通过{@code #key} 引用获取失败的锁的key；</li>
-         *     <li>通过{@code #root} 引用方法对象；</li>
-         *     <li>通过{@code #参数名}或{@code #p参数下标}引用方法的调用参数；</li>
+         * <li>通过{@code #key} 引用获取失败的锁的key；</li>
+         * <li>通过{@code #root} 引用方法对象；</li>
+         * <li>通过{@code #参数名}或{@code #p参数下标}引用方法的调用参数；</li>
          * </ul>
          *
          * @return 错误消息
@@ -199,8 +204,12 @@ public class AbortLockFailureStrategy implements LockFailureStrategy {
         String lockFailureMessage() default DEFAULT_EXCEPTION_MESSAGE;
 
         /**
-         * <p>获取锁失败时，抛出的异常。 <br/>
+         * <p>
+         * 获取锁失败时，抛出的异常。
+         * </p>
+         * <p>
          * 异常类必须提供一个无参构造函数，或者提供一个接受{@code String}类型参数的构造函数。
+         * </p>
          *
          * @return 异常类型
          */

--- a/lock4j-core/src/main/java/com/baomidou/lock/MethodBasedExpressionEvaluator.java
+++ b/lock4j-core/src/main/java/com/baomidou/lock/MethodBasedExpressionEvaluator.java
@@ -16,27 +16,30 @@ public interface MethodBasedExpressionEvaluator {
     /**
      * 执行表达式，返回执行结果
      *
-     * @param method 方法
-     * @param arguments 调用参数
+     * @param <T>        返回值类型
+     * @param method     方法
+     * @param arguments  调用参数
      * @param expression 表达式
      * @param resultType 返回值类型
-     * @param variables 表达式中的变量
+     * @param variables  表达式中的变量
      * @return 表达式执行结果
      */
     <T> T getValue(
-        Method method, Object[] arguments, String expression, Class<T> resultType, @NonNull Map<String, Object> variables);
+            Method method, Object[] arguments, String expression, Class<T> resultType,
+            @NonNull Map<String, Object> variables);
 
     /**
      * 执行表达式，返回执行结果
      *
-     * @param method 方法
-     * @param arguments 调用参数
+     * @param <T>        返回值类型
+     * @param method     方法
+     * @param arguments  调用参数
      * @param expression 表达式
      * @param resultType 返回值类型
      * @return 表达式执行结果
      */
     default <T> T getValue(
-        Method method, Object[] arguments, String expression, Class<T> resultType) {
+            Method method, Object[] arguments, String expression, Class<T> resultType) {
         return getValue(method, arguments, expression, resultType, Collections.emptyMap());
     }
 }

--- a/lock4j-core/src/main/java/com/baomidou/lock/annotation/LockWithDefault.java
+++ b/lock4j-core/src/main/java/com/baomidou/lock/annotation/LockWithDefault.java
@@ -20,7 +20,7 @@ import java.lang.annotation.*;
  */
 @AbortLockFailureStrategy.Options
 @Lock4j(failStrategy = AbortLockFailureStrategy.class)
-@Target(value = {ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Target(value = { ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(value = RetentionPolicy.RUNTIME)
 @Inherited
 @Documented
@@ -54,7 +54,8 @@ public @interface LockWithDefault {
 
     /**
      * @return 过期时间 单位：毫秒
-     * <pre>
+     * 
+     *         <pre>
      *     过期时间一定是要长于业务的执行时间. 未设置则为默认时间30秒 默认值：{@link Lock4jProperties#expire}
      * </pre>
      */
@@ -62,14 +63,16 @@ public @interface LockWithDefault {
 
     /**
      * @return 获取锁超时时间 单位：毫秒
-     * <pre>
+     * 
+     *         <pre>
      *     结合业务,建议该时间不宜设置过长,特别在并发高的情况下. 未设置则为默认时间3秒 默认值：{@link Lock4jProperties#acquireTimeout}
      * </pre>
      */
     long acquireTimeout() default -1;
 
     /**
-     * 业务方法执行完后（方法内抛异常也算执行完）自动释放锁，如果为false，锁将不会自动释放直至到达过期时间才释放 {@link com.baomidou.lock.annotation.Lock4j#expire()}
+     * 业务方法执行完后（方法内抛异常也算执行完）自动释放锁，如果为false，锁将不会自动释放直至到达过期时间才释放
+     * {@link com.baomidou.lock.annotation.Lock4j#expire()}
      *
      * @return 是否自动释放锁
      */
@@ -90,34 +93,34 @@ public @interface LockWithDefault {
     int order() default Ordered.LOWEST_PRECEDENCE;
 
     /**
-     * <p>抛出异常的错误消息。
+     * <p>
+     * 抛出异常的错误消息。
      *
-     * <p>错误信息支持 SpEL 表达式，你可以在表达式中引用上下文参数：
+     * <p>
+     * 错误信息支持 SpEL 表达式，你可以在表达式中引用上下文参数：
      * <ul>
-     *     <li>通过{@code #key} 引用获取失败的锁的key；</li>
-     *     <li>通过{@code #root} 引用方法对象；</li>
-     *     <li>通过{@code #参数名}或{@code #p参数下标}引用方法的调用参数；</li>
+     * <li>通过{@code #key} 引用获取失败的锁的key；</li>
+     * <li>通过{@code #root} 引用方法对象；</li>
+     * <li>通过{@code #参数名}或{@code #p参数下标}引用方法的调用参数；</li>
      * </ul>
      *
      * @return String
      * @see AbortLockFailureStrategy.Options#lockFailureMessage
      */
-    @AliasFor(
-        annotation = AbortLockFailureStrategy.Options.class,
-        attribute = "lockFailureMessage"
-    )
+    @AliasFor(annotation = AbortLockFailureStrategy.Options.class, attribute = "lockFailureMessage")
     String lockFailureMessage() default AbortLockFailureStrategy.DEFAULT_EXCEPTION_MESSAGE;
 
     /**
-     * <p>获取锁失败时，抛出的异常。 <br/>
+     * <p>
+     * 获取锁失败时，抛出的异常。
+     * </p>
+     * <p>
      * 异常类必须提供一个无参构造函数，或者提供一个接受{@code String}类型参数的构造函数。
+     * </p>
      *
      * @return String
      * @see AbortLockFailureStrategy.Options#lockFailureException
      */
-    @AliasFor(
-        annotation = AbortLockFailureStrategy.Options.class,
-        attribute = "lockFailureException"
-    )
+    @AliasFor(annotation = AbortLockFailureStrategy.Options.class, attribute = "lockFailureException")
     Class<? extends Exception> lockFailureException() default LockFailureException.class;
 }

--- a/lock4j-core/src/main/java/com/baomidou/lock/aop/AbstractConditionalLockChainInterceptor.java
+++ b/lock4j-core/src/main/java/com/baomidou/lock/aop/AbstractConditionalLockChainInterceptor.java
@@ -15,9 +15,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * <p>支持多个{@link Lock4j}注解的锁操作拦截器，
- * 当执行时，将会遵循{@link Lock4j}注解的依次进行加锁和解锁操作。<br/>
- * 例如：<br/>
+ * <p>
+ * 支持多个{@link Lock4j}注解的锁操作拦截器，
+ * 当执行时，将会遵循{@link Lock4j}注解的依次进行加锁和解锁操作。
+ * 例如：
+ * 
  * <pre>
  *     &#064;Lock4j(key = "key1", order = 0)
  *     &#064;Lock4j(key = "key2, order = 1)
@@ -26,14 +28,19 @@ import java.util.stream.Collectors;
  *      // do something
  *     }
  * </pre>
+ * 
  * 当执行时，将依次加锁key1、key2、key3，执行完毕后依次解锁key1、key2、key3。
  *
- * <p><strong>中断</strong>
- * <p>多级锁操作链将根据某一环节是否未获取到锁而决定是否中断，若中断则会依次解锁已加锁的锁。
+ * <p>
+ * <strong>中断</strong>
+ * <p>
+ * 多级锁操作链将根据某一环节是否未获取到锁而决定是否中断，若中断则会依次解锁已加锁的锁。
  * 比如，若获取key3锁时失败，则会调用失败处理策略，随后解锁key2，与key1。
  *
- * <p><strong>条件</strong>
- * <p>多级锁的条件是彼此独立的，
+ * <p>
+ * <strong>条件</strong>
+ * <p>
+ * 多级锁的条件是彼此独立的，
  * 比如，若Key2的表达式执行结果为true时，其他表达式执行结果为false，此时将会正常获取Key1与Key2的锁。
  * 同理，若Key2的表达式为false，Key3的表达式为true，此时将会正常获取Key1与Key3的锁
  *
@@ -47,7 +54,7 @@ public abstract class AbstractConditionalLockChainInterceptor extends AbstractCo
      * @param methodBasedExpressionEvaluator 方法调用表达式执行器
      */
     protected AbstractConditionalLockChainInterceptor(
-        MethodBasedExpressionEvaluator methodBasedExpressionEvaluator) {
+            MethodBasedExpressionEvaluator methodBasedExpressionEvaluator) {
         super(methodBasedExpressionEvaluator);
     }
 
@@ -61,10 +68,11 @@ public abstract class AbstractConditionalLockChainInterceptor extends AbstractCo
     @Nullable
     @Override
     protected LockOps resolveLockOps(MethodInvocation invocation) {
-        Set<LockOps> ops = AnnotatedElementUtils.findMergedRepeatableAnnotations(invocation.getMethod(), Lock4j.class).stream()
-            .map(this::createLockOps)
-            .sorted(AnnotationAwareOrderComparator.INSTANCE)
-            .collect(Collectors.toCollection(LinkedHashSet::new));
+        Set<LockOps> ops = AnnotatedElementUtils.findMergedRepeatableAnnotations(invocation.getMethod(), Lock4j.class)
+                .stream()
+                .map(this::createLockOps)
+                .sorted(AnnotationAwareOrderComparator.INSTANCE)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
         if (CollectionUtils.isEmpty(ops)) {
             return null;
         }
@@ -97,14 +105,14 @@ public abstract class AbstractConditionalLockChainInterceptor extends AbstractCo
     protected static class LockOpsChain extends AbstractLockOpsDelegate {
         @Nullable
         private LockOpsChain next;
+
         public LockOpsChain(LockOps delegate) {
             super(delegate);
         }
+
         @Override
         public MethodInvocation attach(MethodInvocation invocation) {
-            return Objects.isNull(next) ?
-                delegate.attach(invocation) :
-                delegate.attach(next.attach(invocation));
+            return Objects.isNull(next) ? delegate.attach(invocation) : delegate.attach(next.attach(invocation));
         }
     }
 }

--- a/lock4j-etcd-spring-boot-starter/pom.xml
+++ b/lock4j-etcd-spring-boot-starter/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  Copyright (c) 2018-2022, baomidou (63976799@qq.com).
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>lock4j</artifactId>
+        <groupId>com.baomidou</groupId>
+        <version>2.2.7</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    
+    <artifactId>lock4j-etcd-spring-boot-starter</artifactId>
+    <packaging>jar</packaging>
+    
+    <dependencies>
+        <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>lock4j-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.etcd</groupId>
+            <artifactId>jetcd-core</artifactId>
+            <version>0.5.11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/lock4j-etcd-spring-boot-starter/src/main/java/com/baomidou/lock/annotation/EtcdLock.java
+++ b/lock4j-etcd-spring-boot-starter/src/main/java/com/baomidou/lock/annotation/EtcdLock.java
@@ -1,0 +1,88 @@
+package com.baomidou.lock.annotation;
+
+import com.baomidou.lock.LockFailureStrategy;
+import com.baomidou.lock.LockKeyBuilder;
+import com.baomidou.lock.executor.EtcdLockExecutor;
+import com.baomidou.lock.spring.boot.autoconfigure.Lock4jProperties;
+import org.springframework.core.Ordered;
+
+import java.lang.annotation.*;
+
+/**
+ * 基于{@link org.redisson.Redisson}实现的分布式锁
+ *
+ * @author huangchengxing
+ * @see Lock4j
+ */
+@Lock4j(executor = EtcdLockExecutor.class)
+@Target(value = {ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(value = RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+public @interface EtcdLock {
+
+    /**
+     * 应用条件表达式，当执行结果为{@code true}或{@code 'true'}时，才会执行锁操作
+     *
+     * @return 名称
+     */
+    String condition() default "";
+
+    /**
+     * 用于多个方法锁同一把锁 可以理解为锁资源名称 为空则会使用 包名+类名+方法名
+     *
+     * @return 名称
+     */
+    String name() default "";
+
+    /**
+     * support SPEL expresion 锁的key = name + keys
+     *
+     * @return KEY
+     */
+    String[] keys() default "";
+
+    /**
+     * @return 过期时间 单位：毫秒
+     * <pre>
+     *     过期时间一定是要长于业务的执行时间. 未设置则为默认时间30秒 默认值：{@link Lock4jProperties#expire}
+     * </pre>
+     */
+    long expire() default -1;
+
+    /**
+     * @return 获取锁超时时间 单位：毫秒
+     * <pre>
+     *     结合业务,建议该时间不宜设置过长,特别在并发高的情况下. 未设置则为默认时间3秒 默认值：{@link Lock4jProperties#acquireTimeout}
+     * </pre>
+     */
+    long acquireTimeout() default -1;
+
+    /**
+     * 业务方法执行完后（方法内抛异常也算执行完）自动释放锁，如果为false，锁将不会自动释放直至到达过期时间才释放 {@link com.baomidou.lock.annotation.Lock4j#expire()}
+     *
+     * @return 是否自动释放锁
+     */
+    boolean autoRelease() default true;
+
+    /**
+     * 失败策略
+     *
+     * @return LockFailureStrategy
+     */
+    Class<? extends LockFailureStrategy> failStrategy() default LockFailureStrategy.class;
+
+    /**
+     * key生成器策略
+     *
+     * @return LockKeyBuilder
+     */
+    Class<? extends LockKeyBuilder> keyBuilderStrategy() default LockKeyBuilder.class;
+
+    /**
+     * 获取顺序，值越小越先执行
+     *
+     * @return 顺序值
+     */
+    int order() default Ordered.LOWEST_PRECEDENCE;
+}

--- a/lock4j-etcd-spring-boot-starter/src/main/java/com/baomidou/lock/executor/EtcdLockExecutor.java
+++ b/lock4j-etcd-spring-boot-starter/src/main/java/com/baomidou/lock/executor/EtcdLockExecutor.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2018-2022, baomidou (63976799@qq.com).
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.baomidou.lock.executor;
+
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.Lease;
+import io.etcd.jetcd.Lock;
+import io.etcd.jetcd.lease.LeaseGrantResponse;
+import io.etcd.jetcd.lock.LockResponse;
+import io.etcd.jetcd.lock.UnlockResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@RequiredArgsConstructor
+public class EtcdLockExecutor extends AbstractLockExecutor<Boolean> {
+
+    private final Client etcdClient;
+
+    private static final long DEFAULT_LEASE_TTL = 30; // 默认租约时间（秒）
+
+    @Override
+    public boolean renewal() {
+        return true;
+    }
+
+    @Override
+    public Boolean acquire(String lockKey, String lockValue, long expire, long acquireTimeout) {
+        try {
+            // 创建租约
+            Lease leaseClient = etcdClient.getLeaseClient();
+            LeaseGrantResponse leaseGrantResponse = leaseClient.grant(DEFAULT_LEASE_TTL).get();
+            long leaseId = leaseGrantResponse.getID();
+
+            // 尝试获取锁
+            Lock lockClient = etcdClient.getLockClient();
+            LockResponse lockResponse = lockClient.lock(bytesOf(lockKey),
+                    leaseId
+            ).get(expire, TimeUnit.SECONDS);
+            // 锁成功获取
+            if (lockResponse != null) {
+                return true;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+
+    @Override
+    public boolean releaseLock(String key, String value, Boolean lockInstance) {
+        try {
+            Lock lockClient = etcdClient.getLockClient();
+            UnlockResponse unlockResponse = lockClient.unlock(bytesOf(key)).get();
+            System.out.println("锁释放成功: " + unlockResponse.toString());
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+        return true;
+    }
+
+    /**
+     * 将字符串转换为字节数组
+     */
+    private ByteSequence bytesOf(String value) {
+        return ByteSequence.from(value.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/lock4j-etcd-spring-boot-starter/src/main/java/com/baomidou/lock/spring/boot/autoconfigure/EtcdLockAutoConfiguration.java
+++ b/lock4j-etcd-spring-boot-starter/src/main/java/com/baomidou/lock/spring/boot/autoconfigure/EtcdLockAutoConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2018-2022, baomidou (63976799@qq.com).
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.baomidou.lock.spring.boot.autoconfigure;
+
+import com.baomidou.lock.executor.EtcdLockExecutor;
+import io.etcd.jetcd.Client;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+
+/**
+ * etcd锁自动配置器
+ *
+ * @author zengzhihong
+ * @author yourname
+ */
+@Configuration
+@EnableConfigurationProperties(EtcdProperties.class)
+class EtcdLockAutoConfiguration {
+
+    @Bean
+    @Order(400)
+    public EtcdLockExecutor etcdLockExecutor(EtcdProperties properties) {
+        Client client = Client.builder()
+                .endpoints(properties.getEndpoints().split(","))
+                .connectTimeout(java.time.Duration.ofMillis(properties.getConnectTimeout()))
+                .build();
+        return new EtcdLockExecutor(client);
+    }
+}

--- a/lock4j-etcd-spring-boot-starter/src/main/java/com/baomidou/lock/spring/boot/autoconfigure/EtcdProperties.java
+++ b/lock4j-etcd-spring-boot-starter/src/main/java/com/baomidou/lock/spring/boot/autoconfigure/EtcdProperties.java
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (c) 2018-2022, baomidou (63976799@qq.com).
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.baomidou.lock.spring.boot.autoconfigure;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * etcd 配置属性
+ *
+ * @author yourname
+ */
+@ConfigurationProperties(prefix = "lock4j.etcd")
+public class EtcdProperties {
+
+    /**
+     * etcd 服务端点，多个端点用逗号分隔
+     */
+    private String endpoints = "http://localhost:2379";
+
+    /**
+     * 连接超时时间（毫秒）
+     */
+    private long connectTimeout = 3000;
+
+    /**
+     * 操作超时时间（毫秒）
+     */
+    private long operationTimeout = 1000;
+
+    /**
+     * 用户名
+     */
+    private String username;
+
+    /**
+     * 密码
+     */
+    private String password;
+
+    /**
+     * 是否启用 SSL
+     */
+    private boolean sslEnabled = false;
+
+    /**
+     * 重试次数
+     */
+    private int retryCount = 3;
+
+    public String getEndpoints() {
+        return endpoints;
+    }
+
+    public void setEndpoints(String endpoints) {
+        this.endpoints = endpoints;
+    }
+
+    public long getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(long connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    public long getOperationTimeout() {
+        return operationTimeout;
+    }
+
+    public void setOperationTimeout(long operationTimeout) {
+        this.operationTimeout = operationTimeout;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public boolean isSslEnabled() {
+        return sslEnabled;
+    }
+
+    public void setSslEnabled(boolean sslEnabled) {
+        this.sslEnabled = sslEnabled;
+    }
+
+    public int getRetryCount() {
+        return retryCount;
+    }
+
+    public void setRetryCount(int retryCount) {
+        this.retryCount = retryCount;
+    }
+}

--- a/lock4j-etcd-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/lock4j-etcd-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+#配置自定义Starter的自动化配置
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.baomidou.lock.spring.boot.autoconfigure.EtcdLockAutoConfiguration

--- a/lock4j-etcd-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/lock4j-etcd-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.baomidou.lock.spring.boot.autoconfigure.EtcdLockAutoConfiguration

--- a/lock4j-etcd-spring-boot-starter/src/test/java/com/baomidou/lock/executor/EtcdLockExecutorTest.java
+++ b/lock4j-etcd-spring-boot-starter/src/test/java/com/baomidou/lock/executor/EtcdLockExecutorTest.java
@@ -1,0 +1,86 @@
+package com.baomidou.lock.executor;
+
+import io.etcd.jetcd.*;
+import io.etcd.jetcd.lease.LeaseGrantResponse;
+import io.etcd.jetcd.lock.LockResponse;
+import io.etcd.jetcd.lock.UnlockResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class EtcdLockExecutorTest {
+
+    @Mock
+    private Client etcdClient;
+    
+    @Mock
+    private Lock lockClient;
+    
+    @Mock
+    private Lease leaseClient;
+    
+    @Mock
+    private LeaseGrantResponse leaseGrantResponse;
+    
+    @Mock
+    private LockResponse lockResponse;
+    
+    @Mock
+    private UnlockResponse unlockResponse;
+
+    private EtcdLockExecutor lockExecutor;
+
+    @BeforeEach
+    void setUp() {
+        lockExecutor = new EtcdLockExecutor(etcdClient);
+    }
+
+    @Test
+    void testRenewal() {
+        assertTrue(lockExecutor.renewal(), "Renewal should return true");
+    }
+
+    @Test
+    void testAcquireLock() throws Exception {
+        String lockKey = "test-lock";
+        String lockValue = "test-value";
+        long expire = 30;
+        long acquireTimeout = 3000;
+
+        // Mock lease grant response
+        when(leaseGrantResponse.getID()).thenReturn(123L);
+        when(leaseClient.grant(anyLong())).thenReturn(CompletableFuture.completedFuture(leaseGrantResponse));
+        when(etcdClient.getLeaseClient()).thenReturn(leaseClient);
+        
+        // Mock lock response
+        when(lockClient.lock(any(ByteSequence.class), anyLong())).thenReturn(CompletableFuture.completedFuture(lockResponse));
+        when(etcdClient.getLockClient()).thenReturn(lockClient);
+
+        boolean result = lockExecutor.acquire(lockKey, lockValue, expire, acquireTimeout);
+        assertTrue(result, "Lock acquisition should succeed with mocked responses");
+    }
+
+    @Test
+    void testReleaseLock() throws Exception {
+        String lockKey = "test-lock";
+        String lockValue = "test-value";
+        Boolean lockInstance = true;
+
+        // Mock unlock response
+        when(lockClient.unlock(any(ByteSequence.class))).thenReturn(CompletableFuture.completedFuture(unlockResponse));
+        when(etcdClient.getLockClient()).thenReturn(lockClient);
+
+        boolean result = lockExecutor.releaseLock(lockKey, lockValue, lockInstance);
+        assertTrue(result, "Lock release should return true");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <nexus-staging.version>1.6.13</nexus-staging.version>
+        <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
         <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
         <redisson.version>3.19.0</redisson.version>
         <curator.version>5.1.0</curator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <module>lock4j-redis-template-spring-boot-starter</module>
         <module>lock4j-redisson-spring-boot-starter</module>
         <module>lock4j-zookeeper-spring-boot-starter</module>
+        <module>lock4j-etcd-spring-boot-starter</module>
         <module>lock4j-test</module>
     </modules>
 
@@ -82,6 +83,7 @@
         <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
         <redisson.version>3.19.0</redisson.version>
         <curator.version>5.1.0</curator.version>
+        <jetcd.version>0.5.11</jetcd.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,25 @@
                     <generateBackupPoms>false</generateBackupPoms>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.8</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION

**What kind of change does this PR introduce?** (check at least one)


- [ ] Bugfix

- [x] Feature

- [ ] Code style update

- [ ] Refactor

- [ ] Doc

- [ ] Other, please describe:


**The description of the PR:**

This PR adds support for etcd-based distributed locking in lock4j. The implementation includes:


- New module `lock4j-etcd-spring-boot-starter`

- `EtcdLockExecutor` for handling etcd-specific lock operations

- `EtcdLockAutoConfiguration` for automatic configuration in Spring Boot applications

- `EtcdProperties` for configuring etcd connection details

- Unit tests for the etcd lock implementation

This feature allows users to leverage etcd as a backend for distributed locking in addition to the existing options like Redis and Zookeeper.


